### PR TITLE
allow non Devise models has `encrypted_password` field.

### DIFF
--- a/lib/rails_admin/config/fields/factories/devise.rb
+++ b/lib/rails_admin/config/fields/factories/devise.rb
@@ -4,7 +4,7 @@ require 'rails_admin/config/fields/types/password'
 
 # Register a custom field factory for devise model
 RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
-  if properties.name == :encrypted_password
+  if properties.name == :encrypted_password and parent.abstract_model.model.public_instance_methods.include?(:password_confirmation=)
     extensions = [:password_salt, :reset_password_token, :remember_token]
     fields << RailsAdmin::Config::Fields::Types.load(:password).new(parent, :password, properties)
     fields << RailsAdmin::Config::Fields::Types.load(:password).new(parent, :password_confirmation, properties)


### PR DESCRIPTION
If a model has `encrypted_password` column but it isn't devise's resource model, it turned out that rails_admin cause error on create/update the instance of the model.

```
I, [2016-02-01T15:43:29.713905 #31900]  INFO -- : Processing by RailsAdmin::MainController#new as JSON
I, [2016-02-01T15:43:30.278383 #31900]  INFO -- : Completed 500 Internal Server Error in 564ms (ActiveRecord: 140.5ms)
F, [2016-02-01T15:43:30.280641 #31900] FATAL -- :
ActiveRecord::UnknownAttributeError (unknown attribute: password_confirmation):
  /data/magellan_api/shared/bundle/ruby/2.2.0/bundler/gems/rails_admin-63e7048bba01/lib/rails_admin/adapters/active_record/abstract_object.rb:19:in `set_attributes'
  lib/rails_admin/actions/new.rb:39:in `block (2 levels) in <class:New>'
  /data/magellan_api/shared/bundle/ruby/2.2.0/bundler/gems/rails_admin-63e7048bba01/app/controllers/rails_admin/main_controller.rb:22:in `instance_eval'
  /data/magellan_api/shared/bundle/ruby/2.2.0/bundler/gems/rails_admin-63e7048bba01/app/controllers/rails_admin/main_controller.rb:22:in `new'
<snip>
```

Add condition to check if the model has `password_confirmation=` method to confirm it is really devise's resource model.
- [x] @akm 
- [x] @kamito 
